### PR TITLE
[Fix] unqualified call error when building with clang versions above 14

### DIFF
--- a/ext/backward/backward.hpp
+++ b/ext/backward/backward.hpp
@@ -1639,9 +1639,9 @@ private:
       return r; // damned, that's a stripped file that you got there!
     }
 
-    r->handle = move(bfd_handle);
-    r->symtab = move(symtab);
-    r->dynamic_symtab = move(dynamic_symtab);
+    r->handle = std::move(bfd_handle);
+    r->symtab = std::move(symtab);
+    r->dynamic_symtab = std::move(dynamic_symtab);
     return r;
   }
 


### PR DESCRIPTION
Resolves "unqualified call to 'std::move'" error when building with clang versions above 14. Tested with clang versions 15.0.7 & 16.0.6 on Gentoo, as well as clang 14.0.0 on Ubuntu 22.04 LTS.