### PR TITLE
Gentoo workflow change use

### DIFF
--- a/.github/workflows/Gentoo.yml
+++ b/.github/workflows/Gentoo.yml
@@ -3,7 +3,7 @@ name: "Gentoo build"
 on:
   push:
     branches:
-      - gentoo-workflow-clang17
+      - base
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/Gentoo.yml
+++ b/.github/workflows/Gentoo.yml
@@ -3,7 +3,7 @@ name: "Gentoo build"
 on:
   push:
     branches:
-      - base
+      - gentoo-workflow-clang17
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -28,6 +28,10 @@ jobs:
         echo '[gentoo]
         sync-type = webrsync' >> /etc/portage/repos.conf/gentoo.conf
         emerge --sync
+        emerge --quiet-build --oneshot dev-qt/qtcore
+        emerge --quiet-build --oneshot dev-qt/qtgui
+        emerge --quiet-build --oneshot dev-qt/qtdbus
+        emerge --quiet-build --oneshot sys-libs/libomp
         emerge --quiet-build app-eselect/eselect-repository dev-vcs/git
         eselect repository add claytabase git https://github.com/claybie/claytabase.git
         eselect repository enable guru
@@ -208,6 +212,10 @@ jobs:
         echo '[gentoo]
         sync-type = webrsync' >> /etc/portage/repos.conf/gentoo.conf
         emerge --sync
+        emerge --quiet-build --oneshot dev-qt/qtcore
+        emerge --quiet-build --oneshot dev-qt/qtgui
+        emerge --quiet-build --oneshot dev-qt/qtdbus
+        emerge --quiet-build --oneshot sys-libs/libomp
         emerge --quiet-build app-eselect/eselect-repository dev-vcs/git
         eselect repository add claytabase git https://github.com/claybie/claytabase.git
         eselect repository enable guru
@@ -253,6 +261,10 @@ jobs:
         echo '[gentoo]
         sync-type = webrsync' >> /etc/portage/repos.conf/gentoo.conf
         emerge --sync
+        emerge --quiet-build --oneshot dev-qt/qtcore
+        emerge --quiet-build --oneshot dev-qt/qtgui
+        emerge --quiet-build --oneshot dev-qt/qtdbus
+        emerge --quiet-build --oneshot sys-libs/libomp
         emerge --quiet-build app-eselect/eselect-repository dev-vcs/git
         eselect repository add claytabase git https://github.com/claybie/claytabase.git
         eselect repository enable guru
@@ -307,6 +319,10 @@ jobs:
         echo '[gentoo]
         sync-type = webrsync' >> /etc/portage/repos.conf/gentoo.conf
         emerge --sync
+        emerge --quiet-build --oneshot dev-qt/qtcore
+        emerge --quiet-build --oneshot dev-qt/qtgui
+        emerge --quiet-build --oneshot dev-qt/qtdbus
+        emerge --quiet-build --oneshot sys-libs/libomp
         emerge --quiet-build app-eselect/eselect-repository dev-vcs/git
         eselect repository add claytabase git https://github.com/claybie/claytabase.git
         eselect repository enable guru
@@ -370,6 +386,10 @@ jobs:
         echo '[gentoo]
         sync-type = webrsync' >> /etc/portage/repos.conf/gentoo.conf
         emerge --sync
+        emerge --quiet-build --oneshot dev-qt/qtcore
+        emerge --quiet-build --oneshot dev-qt/qtgui
+        emerge --quiet-build --oneshot dev-qt/qtdbus
+        emerge --quiet-build --oneshot sys-libs/libomp
         emerge --quiet-build app-eselect/eselect-repository dev-vcs/git
         eselect repository add claytabase git https://github.com/claybie/claytabase.git
         eselect repository enable guru

--- a/.github/workflows/Gentoo.yml
+++ b/.github/workflows/Gentoo.yml
@@ -23,15 +23,12 @@ jobs:
         echo 'FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox binpkg-request-signature"' >> /etc/portage/make.conf
         echo 'EMERGE_DEFAULT_OPTS="--binpkg-changed-deps=n --binpkg-respect-use=n --getbinpkg=y"' >> /etc/portage/make.conf
         echo 'MAKEOPTS="-j4"' >> /etc/portage/make.conf
+        echo 'USE="-qt5 -qt6 -gtk"' >> /etc/portage/make.conf
         mkdir /etc/portage/repos.conf
         touch /etc/portage/repos.conf/gentoo.conf
         echo '[gentoo]
         sync-type = webrsync' >> /etc/portage/repos.conf/gentoo.conf
         emerge --sync
-        emerge --quiet-build --oneshot dev-qt/qtcore
-        emerge --quiet-build --oneshot dev-qt/qtgui
-        emerge --quiet-build --oneshot dev-qt/qtdbus
-        emerge --quiet-build --oneshot sys-libs/libomp
         emerge --quiet-build app-eselect/eselect-repository dev-vcs/git
         eselect repository add claytabase git https://github.com/claybie/claytabase.git
         eselect repository enable guru
@@ -207,15 +204,12 @@ jobs:
         echo 'FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox binpkg-request-signature"' >> /etc/portage/make.conf
         echo 'EMERGE_DEFAULT_OPTS="--binpkg-changed-deps=n --binpkg-respect-use=n --getbinpkg=y"' >> /etc/portage/make.conf
         echo 'MAKEOPTS="-j4"' >> /etc/portage/make.conf
+        echo 'USE="-qt5 -qt6 -gtk"' >> /etc/portage/make.conf
         mkdir /etc/portage/repos.conf
         touch /etc/portage/repos.conf/gentoo.conf
         echo '[gentoo]
         sync-type = webrsync' >> /etc/portage/repos.conf/gentoo.conf
         emerge --sync
-        emerge --quiet-build --oneshot dev-qt/qtcore
-        emerge --quiet-build --oneshot dev-qt/qtgui
-        emerge --quiet-build --oneshot dev-qt/qtdbus
-        emerge --quiet-build --oneshot sys-libs/libomp
         emerge --quiet-build app-eselect/eselect-repository dev-vcs/git
         eselect repository add claytabase git https://github.com/claybie/claytabase.git
         eselect repository enable guru
@@ -256,15 +250,12 @@ jobs:
         echo 'FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox binpkg-request-signature"' >> /etc/portage/make.conf
         echo 'EMERGE_DEFAULT_OPTS="--binpkg-changed-deps=n --binpkg-respect-use=n --getbinpkg=y"' >> /etc/portage/make.conf
         echo 'MAKEOPTS="-j4"' >> /etc/portage/make.conf
+        echo 'USE="-qt5 -qt6 -gtk"' >> /etc/portage/make.conf
         mkdir /etc/portage/repos.conf
         touch /etc/portage/repos.conf/gentoo.conf
         echo '[gentoo]
         sync-type = webrsync' >> /etc/portage/repos.conf/gentoo.conf
         emerge --sync
-        emerge --quiet-build --oneshot dev-qt/qtcore
-        emerge --quiet-build --oneshot dev-qt/qtgui
-        emerge --quiet-build --oneshot dev-qt/qtdbus
-        emerge --quiet-build --oneshot sys-libs/libomp
         emerge --quiet-build app-eselect/eselect-repository dev-vcs/git
         eselect repository add claytabase git https://github.com/claybie/claytabase.git
         eselect repository enable guru
@@ -314,15 +305,12 @@ jobs:
         echo 'FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox binpkg-request-signature"' >> /etc/portage/make.conf
         echo 'EMERGE_DEFAULT_OPTS="--binpkg-changed-deps=n --binpkg-respect-use=n --getbinpkg=y"' >> /etc/portage/make.conf
         echo 'MAKEOPTS="-j4"' >> /etc/portage/make.conf
+        echo 'USE="-qt5 -qt6 -gtk"' >> /etc/portage/make.conf
         mkdir /etc/portage/repos.conf
         touch /etc/portage/repos.conf/gentoo.conf
         echo '[gentoo]
         sync-type = webrsync' >> /etc/portage/repos.conf/gentoo.conf
         emerge --sync
-        emerge --quiet-build --oneshot dev-qt/qtcore
-        emerge --quiet-build --oneshot dev-qt/qtgui
-        emerge --quiet-build --oneshot dev-qt/qtdbus
-        emerge --quiet-build --oneshot sys-libs/libomp
         emerge --quiet-build app-eselect/eselect-repository dev-vcs/git
         eselect repository add claytabase git https://github.com/claybie/claytabase.git
         eselect repository enable guru
@@ -381,15 +369,12 @@ jobs:
         echo 'FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox binpkg-request-signature"' >> /etc/portage/make.conf
         echo 'EMERGE_DEFAULT_OPTS="--binpkg-changed-deps=n --binpkg-respect-use=n --getbinpkg=y"' >> /etc/portage/make.conf
         echo 'MAKEOPTS="-j4"' >> /etc/portage/make.conf
+        echo 'USE="-qt5 -qt6 -gtk"' >> /etc/portage/make.conf
         mkdir /etc/portage/repos.conf
         touch /etc/portage/repos.conf/gentoo.conf
         echo '[gentoo]
         sync-type = webrsync' >> /etc/portage/repos.conf/gentoo.conf
         emerge --sync
-        emerge --quiet-build --oneshot dev-qt/qtcore
-        emerge --quiet-build --oneshot dev-qt/qtgui
-        emerge --quiet-build --oneshot dev-qt/qtdbus
-        emerge --quiet-build --oneshot sys-libs/libomp
         emerge --quiet-build app-eselect/eselect-repository dev-vcs/git
         eselect repository add claytabase git https://github.com/claybie/claytabase.git
         eselect repository enable guru


### PR DESCRIPTION
This should lessen the chance of a portage emerge error due to slot conflicts; workflow should not be building packages with gui components anyway.